### PR TITLE
feat: pass every unknown props/attrs to VAutocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,20 +80,12 @@ That means if `place` is equal to `30 Rue du Sergent Michel Berthet, Lyon`, it w
 
 ### Props
 
-| Name        | Type        | Default                             | Example        | Comment  |
-| ----------- | ----------- | ----------------------------------- | -------------- | -------- |
-| `language`  | `String`    |  `navigator.language.split('-')[0]` | `'fr'`         | Two letters country code ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements)) |
-| `countries` | `String[]`  |  The whole planet                   | `['fr', 'be']` | Array of two letters country codes ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements)) |
+| Name        | Type       | Default                             | Example        | Comment                                                                                                                      |
+| ----------- | ---------- | ----------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `language`  | `String`   |  `navigator.language.split('-')[0]` | `'fr'`         | Two letters country code ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements))           |
+| `countries` | `String[]` |  The whole planet                   | `['fr', 'be']` | Array of two letters country codes ([ISO 639-1](https://en.wikipedia.org/wiki/ISO_3166-1#Officially_assigned_code_elements)) |
 
-Some [Vuetify Autocomplete component](https://vuetifyjs.com/en/components/autocompletes#api) props are also supported:
- 
-| Name              | Type      | Default                                                   | Comment |
-| ----------------- | --------- | --------------------------------------------------------- | ------- |
-| `disabled`        | `Boolean` |  `false`                                                  | |
-| `required`        | `Boolean` |  `false`                                                  | Does not work anymore since Vuetify 1.1 |
-| `requiredMessage` | `String`  |  `'You must select a place'`                              | Does not work anymore since Vuetify 1.1 |
-| `rules`           | `Array`   |  `[v => (v && v.value !== '') \|\| this.requiredMessage]` | |
-| `label`           | `String`  |  `'Select a location'`                                    | |
+Every props from [Vuetify Autocomplete component](https://vuetifyjs.com/en/components/autocompletes#api) are supported, except `items`, `loading`, `search-input.sync`, `filter`, `return-object` and `append-icon` that are used internally.
 
 ### Events
 

--- a/src/VuetifyAlgoliaPlaces.vue
+++ b/src/VuetifyAlgoliaPlaces.vue
@@ -1,15 +1,12 @@
 <template>
   <v-autocomplete
     v-model="place"
+    v-bind="$attrs"
+    v-on="$listeners"
     :items="places"
     :loading="loading"
     :search-input.sync="query"
     :filter="filter"
-    :disabled="disabled"
-    :required="required"
-    :rules="validationRules"
-    :label="label"
-    single-line
     return-object
     item-text="value"
     append-icon="location_on"
@@ -52,29 +49,6 @@ export default {
       default() {
         return [];
       },
-    },
-    // Vuetify props
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
-    required: {
-      type: Boolean,
-      default: false,
-    },
-    requiredMessage: {
-      type: String,
-      default: 'You must select a place',
-    },
-    rules: {
-      type: Array,
-      default() {
-        return [v => (v && v.value !== '') || this.requiredMessage];
-      },
-    },
-    label: {
-      type: String,
-      default: '',
     },
   },
   data() {


### PR DESCRIPTION
Close #119.

This way, we don't have to define and support manually a tons of VAutocomplete props. We pass what we don't know to `<v-autocomplete>`.