### PR TITLE
feat: add custom highlight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ That means if `place` is equal to `30 Rue du Sergent Michel Berthet, Lyon`, it w
 | `aroundLatLngViaIp` | `Boolean`        | Check [`aroundLatLngViaIP` option](https://community.algolia.com/places/documentation.html#api-options-aroundLatLngViaIP) |
 | `aroundRadius`      | `Number`         | Check [`aroundRadius` option](https://community.algolia.com/places/documentation.html#api-options-aroundRadius)           |
 | `debounce`          | `Number|Boolean` | Pass `true` to debounce for 250ms, or pass a custom delay. Default: `false`                                               |
-|  |
+|                     |
 
 Every props from [Vuetify Autocomplete component](https://vuetifyjs.com/en/components/autocompletes#api) are supported, except `items`, `loading`, `search-input.sync`, `filter` and `return-object` that are used internally.
 
@@ -107,7 +107,7 @@ Every props from [Vuetify Autocomplete component](https://vuetifyjs.com/en/compo
 
 ### Custom highlighting
 
-You can override the default behavior of highlighted search query hits via a custom function and/or slot. When using both, the returned value of your custom highlight function will become the `highlight` prop in the slot.
+You can override the default behavior of highlighted search query hits via a custom function and/or slot. When using both, the returned value of your custom highlight function will become the `highlight` prop in the slot. Read more about Algolia Places highlight object [here](https://community.algolia.com/places/documentation.html#api-suggestion-value).
 
 #### Via function
 

--- a/README.md
+++ b/README.md
@@ -84,15 +84,16 @@ That means if `place` is equal to `30 Rue du Sergent Michel Berthet, Lyon`, it w
 
 ### Props
 
-| Name                | Type              | Algolia Places documentation                                                                                              |
-| ------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `type`              |  `String`         | Check [`type` option](https://community.algolia.com/places/documentation.html#api-options-type)                           |
-| `language`          | `String`          | Check [`language` option](https://community.algolia.com/places/documentation.html#api-options-language)                   |
-| `countries`         | `String[]`        | Check [`countries` option](https://community.algolia.com/places/documentation.html#api-options-countries)                 |
-| `aroundLatLng`      | `String`          | Check [`aroundLatLng` option](https://community.algolia.com/places/documentation.html#api-options-aroundLatLng)           |
-| `aroundLatLngViaIp` | `Boolean`         | Check [`aroundLatLngViaIP` option](https://community.algolia.com/places/documentation.html#api-options-aroundLatLngViaIP) |
-| `aroundRadius`      | `Number`          | Check [`aroundRadius` option](https://community.algolia.com/places/documentation.html#api-options-aroundRadius)           |
-| `debounce`          | `Number\|Boolean` |  Pass `true` to debounce for 250ms, or pass a custom delay. Default: `false`                                              |
+| Name                | Type             | Algolia Places documentation                                                                                              |
+| ------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `type`              |  `String`        | Check [`type` option](https://community.algolia.com/places/documentation.html#api-options-type)                           |
+| `language`          | `String`         | Check [`language` option](https://community.algolia.com/places/documentation.html#api-options-language)                   |
+| `countries`         | `String[]`       | Check [`countries` option](https://community.algolia.com/places/documentation.html#api-options-countries)                 |
+| `aroundLatLng`      | `String`         | Check [`aroundLatLng` option](https://community.algolia.com/places/documentation.html#api-options-aroundLatLng)           |
+| `aroundLatLngViaIp` | `Boolean`        | Check [`aroundLatLngViaIP` option](https://community.algolia.com/places/documentation.html#api-options-aroundLatLngViaIP) |
+| `aroundRadius`      | `Number`         | Check [`aroundRadius` option](https://community.algolia.com/places/documentation.html#api-options-aroundRadius)           |
+| `debounce`          | `Number|Boolean` | Pass `true` to debounce for 250ms, or pass a custom delay. Default: `false`                                               |
+|  |
 
 Every props from [Vuetify Autocomplete component](https://vuetifyjs.com/en/components/autocompletes#api) are supported, except `items`, `loading`, `search-input.sync`, `filter` and `return-object` that are used internally.
 
@@ -103,3 +104,25 @@ Every props from [Vuetify Autocomplete component](https://vuetifyjs.com/en/compo
 | `input` | Emitted when the user select a place                                            | `@input="onInput"`, `onInput(place) { }`  |
 | `error` | Emitted when there is an error with Algolia API                                 |  `@error="onError"`, `onError(error) { }` |
 | `clear` |  Emitted when the user click on the _clear button_ (used with prop `clearable`) | `@clear="onClear"`, `onClear() { }`       |
+
+### Custom highlighting
+
+You can override the default behavior of highlighted search query hits via a custom function and/or slot. When using both, the returned value of your custom highlight function will become the `highlight` prop in the slot.
+
+#### Via function
+
+```
+<vuetify-algolia-places :custom-highlight="someFunction" />
+```
+
+#### Via slot
+
+Note that this slot's parent element is a `<v-list-tile-content>`
+
+```
+<vuetify-algolia-places>
+  <template v-slot:highlight="{ highlight }">
+    <v-list-tile-title>{{ highlight }}</v-list-tile-title>
+  </template>
+</vuetify-algolia-places>
+```

--- a/src/VuetifyAlgoliaPlaces.vue
+++ b/src/VuetifyAlgoliaPlaces.vue
@@ -2,7 +2,6 @@
   <v-autocomplete
     v-model="place"
     v-bind="$attrs"
-    v-on="$listeners"
     :items="places"
     :loading="loading"
     :search-input.sync="query"
@@ -10,16 +9,19 @@
     return-object
     item-text="value"
     :append-icon="appendIcon"
+    v-on="$listeners"
     @input="onInput"
     @click:clear="onClear"
   >
-    <template slot="item" slot-scope="data">
-      <template v-if="typeof data.item !== 'object'">
-        <v-list-tile-content>{{ data.item }}</v-list-tile-content>
+    <template v-slot:item="{ item }">
+      <template v-if="typeof item !== 'object'">
+        <v-list-tile-content>{{ item }}</v-list-tile-content>
       </template>
       <template v-else>
         <v-list-tile-content>
-          <v-list-tile-title v-if="data.item.highlight" v-html="fixHighlight(data.item.highlight)" />
+          <slot name="highlight" :highlight="item.highlight">
+            <v-list-tile-title v-html="item.highlight" />
+          </slot>
         </v-list-tile-content>
       </template>
     </template>
@@ -76,6 +78,30 @@ export default {
     appendIcon: {
       type: String,
       default: 'location_on',
+    },
+    customHighlight: {
+      type: Function,
+      default: initialHighlight => {
+        const highlight = Object.assign({}, initialHighlight); // eslint-disable-line
+        const replace = value => (value || '').replace(/<em>/g, '<b>').replace(/<\/em>/g, '</b>');
+
+        Object.entries(highlight).forEach(([key, value]) => {
+          highlight[key] = replace(value);
+        });
+
+        let ret = highlight.name;
+        if (highlight.city) {
+          ret += `, <small>${highlight.city}</small>`;
+        }
+        if (highlight.administrative) {
+          ret += `<small>, ${highlight.administrative}</small>`;
+        }
+        if (highlight.country) {
+          ret += `<small>, ${highlight.country}</small>`;
+        }
+
+        return ret;
+      },
     },
   },
   data() {
@@ -179,15 +205,20 @@ export default {
         .search(this.searchOptions)
         .then(content => {
           this.loading = false;
-          this.places = content.hits.map((hit, hitIndex) =>
-            formatHit({
-              formatInputValue,
-              hit,
-              hitIndex,
-              query: this.query,
-              rawAnswer: content,
-            })
-          );
+          this.places = content.hits
+            .map((hit, hitIndex) =>
+              formatHit({
+                formatInputValue,
+                hit,
+                hitIndex,
+                query: this.query,
+                rawAnswer: content,
+              })
+            )
+            // formatHit() reforms Algolia's _highlightResult object into a highlight prop in the root of each item.
+            // Making a second pass to apply the highlight function to each array item should have a negligible
+            // performance difference, since the highlight function was originally being called in a v-for in the template
+            .map(p => ({ ...p, highlight: this.customHighlight(p.highlight) }));
 
           if (typeof this.places[0] === 'object') {
             callback(this.places[0]);
@@ -207,27 +238,6 @@ export default {
     onClear() {
       this.$emit('input', null);
       this.$emit('clear');
-    },
-    fixHighlight(initialHighlight) {
-      const highlight = Object.assign({}, initialHighlight); // eslint-disable-line
-      const replace = value => (value || '').replace(/<em>/g, '<b>').replace(/<\/em>/g, '</b>');
-
-      Object.entries(highlight).forEach(([key, value]) => {
-        highlight[key] = replace(value);
-      });
-
-      let ret = highlight.name;
-      if (highlight.city) {
-        ret += `, <small>${highlight.city}</small>`;
-      }
-      if (highlight.administrative) {
-        ret += `<small>, ${highlight.administrative}</small>`;
-      }
-      if (highlight.country) {
-        ret += `<small>, ${highlight.country}</small>`;
-      }
-
-      return ret;
     },
   },
 };


### PR DESCRIPTION
- added `custom-highlight` prop that accepts a function to override the default highlight function
- added a slot to further customize the highlight template
- updated README with example